### PR TITLE
Fix to avoid opening multiple windows for the same app

### DIFF
--- a/pages/members.html
+++ b/pages/members.html
@@ -55,6 +55,11 @@
             <p>D4774</p>
             <p> |  </p>
         </div>
+
+        <div id="qbit">
+            <p>QBit</p>
+            <p> Web Exploitation & Security | OSINT </p>
+        </div>
     </div>
 </body>
 </html>

--- a/scripts/ss_os.js
+++ b/scripts/ss_os.js
@@ -331,6 +331,18 @@ class ss_desktop {
     addWindow = (e) => {
         const { containerEl } = this;
         const appEl = e.target;
+        
+        // Check if a window for this application is already open
+        const appHref = appEl.getAttribute('href');
+        const existingWindow = this.openWindows.find(window => window.href === appHref);
+        
+        if (existingWindow) {
+            // If window exists, bring it to front
+            this.raiseWindow(existingWindow);
+            return;
+        }
+        
+        // Create new window if none exists
         const w = new ss_window(containerEl, appEl, (this.openWindows.length + 1) * 1000, this);
         this.openWindows.push(w);
     };


### PR DESCRIPTION
* Updated `addWindow` to check if the app is already open.
* If open, it brings the window to the front using `raiseWindow()`.
* Creates a new window only if no existing window is found.

This change prevents multiple windows from opening when clicking the same icon.